### PR TITLE
TB ver2 (fixed)

### DIFF
--- a/ezufo_helpers/find_360_overlap.py
+++ b/ezufo_helpers/find_360_overlap.py
@@ -200,8 +200,6 @@ def main():
 
         tifffile.imsave(os.path.join(proc, 'sinos', 'axis-'+axis_str+'.tif'), output_img.astype(np.float32))
 
-np.concatenate()
-
     # remove output directory if it exists (to prevent blending results from different ranges in same folder)
     # otherwise make the output directory
     if os.path.exists(output):

--- a/ezufo_helpers/find_360_overlap.py
+++ b/ezufo_helpers/find_360_overlap.py
@@ -190,7 +190,7 @@ def main():
         stitched_sino = np.concatenate(sino_halves, axis=1)
 
         # crop to minimum image dimensions so that they can be opened as stack
-        output_img = (stitched_sino[:,:output_width])
+        output_img = (stitched_sino[:,(stitched_sino.shape[1]//2-output_width//2):(stitched_sino.shape[1]//2+output_width//2)])
 
         # calculate real axis for filename (adjust if it's on the right)
         if axis_on_left:
@@ -200,6 +200,7 @@ def main():
 
         tifffile.imsave(os.path.join(proc, 'sinos', 'axis-'+axis_str+'.tif'), output_img.astype(np.float32))
 
+np.concatenate()
 
     # remove output directory if it exists (to prevent blending results from different ranges in same folder)
     # otherwise make the output directory


### PR DESCRIPTION
following updates were made:
    - 1D fft ring removal is now an option (turned off by default)
    - sinogram halves are now cached so that the whole dataset doesn't have to be reloaded when the same input folder and row number are used (makes searching multiple ranges much faster)
    -memory in which to store image sequences is now pre-allocated (rather than dynamically allocated)
    -output sinograms and reconstructions are now cropped to same dimensions so they can be loaded as a sequence in ImageJ
    -the case where the axis of rotation is in the right-hand side of the image is now handled
    -the location of the axis (left- or right-hand) is now automatically detected from the input range
    
the following fixes were made:
    - absence of "flats2" directory no longer results in error
    - the output directory is cleaned and rewritten (not appended, which can cause confusing results in some cases)
    - added try/finally handling to ensure that the sinos tmp folder is always deleted if exception is thrown (no proper exception handling is currently implemented)


